### PR TITLE
Fix 'bloch' import.

### DIFF
--- a/bloch/__init__.py
+++ b/bloch/__init__.py
@@ -1,0 +1,1 @@
+from .bloch import bloch

--- a/bloch/bloch.py
+++ b/bloch/bloch.py
@@ -43,7 +43,20 @@ def bloch(b1, gr, tp, t1, t2, df, dp, mode, mx=None, my=None, mz=None):
     """
     if isinstance(b1, NUMBER):
         b1 = np.ones(1) * b1
-    ntime = b1.size
+    if b1.ndim == 1:
+        b1 = np.expand_dims(b1, 0)
+    ntime = b1.size[1]
+
+    assert gr.ndim == 2 and gr.shape[0] <= 3 and gr.shape[1] == ntime, 'gr is of the wrong shape.'
+
+    tp_flag = False
+    tp_flag |= isinstance(tp, NUMBER)
+    tp_flag |= (tp.ndim == 1)
+    if tp.ndim == 2:
+        tp_flag |= (tp.shape[0] == 1) and ((tp.shape[1] == 1) or (tp.shape[1] == ntime))
+    else:
+        tp_flag |= False
+    assert tp_flag, 'tp is of the wrong shape.'
 
     grx, gry, grz = process_gradient_argument(gr, ntime)
     tp = process_time_points(tp, ntime)

--- a/bloch/bloch.py
+++ b/bloch/bloch.py
@@ -4,7 +4,7 @@ import scipy as sp
 from bloch.bloch_simulator import bloch_c
 
 from bloch.bloch_processing import NUMBER
-from bloch.bloch_processing import process_gradient_argument, process_time_points, process_off_resonance_arguments
+from bloch.bloch_processing import process_rf_argument, process_gradient_argument, process_time_points, process_off_resonance_arguments
 from bloch.bloch_processing import process_positions, process_magnetization, reshape_matrices
 from bloch.bloch_processing import process_relaxations
 
@@ -41,23 +41,7 @@ def bloch(b1, gr, tp, t1, t2, df, dp, mode, mx=None, my=None, mz=None):
             mx,my,mz = NxP arrays of the resulting magnetization
                             components at each position and frequency.
     """
-    if isinstance(b1, NUMBER):
-        b1 = np.ones(1) * b1
-    if b1.ndim == 1:
-        b1 = np.expand_dims(b1, 0)
-    ntime = b1.size[1]
-
-    assert gr.ndim == 2 and gr.shape[0] <= 3 and gr.shape[1] == ntime, 'gr is of the wrong shape.'
-
-    tp_flag = False
-    tp_flag |= isinstance(tp, NUMBER)
-    tp_flag |= (tp.ndim == 1)
-    if tp.ndim == 2:
-        tp_flag |= (tp.shape[0] == 1) and ((tp.shape[1] == 1) or (tp.shape[1] == ntime))
-    else:
-        tp_flag |= False
-    assert tp_flag, 'tp is of the wrong shape.'
-
+    b1, ntime = process_rf_argument(b1)
     grx, gry, grz = process_gradient_argument(gr, ntime)
     tp = process_time_points(tp, ntime)
     df, nf = process_off_resonance_arguments(df)

--- a/bloch/bloch_processing.py
+++ b/bloch/bloch_processing.py
@@ -1,6 +1,8 @@
 import numpy as np
 import scipy as sp
 
+import warnings
+
 NUMBER = (int, float, complex)
 
 #Functions to handle preprocessing for bloch simulator arguments.
@@ -27,6 +29,8 @@ def process_gradient_argument(gr, points):
     if isinstance(gr, NUMBER):
         return gr * np.ones(points), np.zeros(points), np.zeros(points)
     elif 1 == gr.ndim:
+        if gr.shape[0] <= 3:
+            warnings.warn("A 1-dim gradient array of size <= 3 is ambiguous. The array will be treated as a 1x{} array".format(gr.shape[0]))
         return gr, np.zeros(points), np.zeros(points)
 
     assert 2 == gr.ndim, 'Gradient argument must be a scalar or a numpy array having 1 or 2 dimensions'

--- a/bloch/bloch_processing.py
+++ b/bloch/bloch_processing.py
@@ -5,6 +5,19 @@ NUMBER = (int, float, complex)
 
 #Functions to handle preprocessing for bloch simulator arguments.
 
+def process_rf_argument(b1):
+    """
+    Checks the shape of the RF argument and promotes if needed.
+    """
+    if isinstance(b1, NUMBER):
+        b1 = np.ones(1) * b1
+
+    if b1.ndim == 1:
+        b1 = np.expand_dims(b1, 0)
+
+    assert b1.ndim == 2 and b1.shape[0] == 1, 'b1 is of the wrong shape.'
+    return b1, b1.shape[1]
+
 def process_gradient_argument(gr, points):
     """
     Takes in a gradient argument and returns directional gradients.
@@ -13,10 +26,16 @@ def process_gradient_argument(gr, points):
     """
     if isinstance(gr, NUMBER):
         return gr * np.ones(points), np.zeros(points), np.zeros(points)
-    elif 1 == len(gr.shape):
+    elif 1 == gr.ndim:
         return gr, np.zeros(points), np.zeros(points)
 
+    assert 2 == gr.ndim, 'Gradient argument must be a scalar or a numpy array having 1 or 2 dimensions'
+
+    if gr.shape[1] != points:
+        raise IndexError("Gradient length is not equal to RF length")
+
     gradient_dimensions = gr.shape[0]
+    assert gradient_dimensions <= 3, 'Axis 0 of the gradient array must be of size <= 3'
 
     if 3 == gradient_dimensions:
         return gr[0,:], gr[1,:], gr[2,:]
@@ -36,7 +55,13 @@ def process_time_points(tp, points):
     """
     if isinstance(tp, NUMBER):
         return tp * np.ones(points)
-    elif points != tp.size:
+
+    if tp.ndim == 2:
+        assert tp.shape[0] == 1, 'Axis 0 of the array of time points must be of size 1'
+    else:
+        assert tp.ndim <= 2, 'The array of time points may have at most 2 dimensions'
+
+    if points != tp.shape[-1]:
         raise IndexError("time point length is not equal to rf length")
     else:
         ti = np.zeros(points)

--- a/bloch/tests/test_bloch.py
+++ b/bloch/tests/test_bloch.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 import scipy.io as sio
 
-from bloch.bloch import bloch
+from bloch import bloch
 
 TEST_DIR = "bloch/tests/test_data"
 

--- a/bloch/tests/test_rf_seq.py
+++ b/bloch/tests/test_rf_seq.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 import scipy as sp
 
-from bloch.bloch import bloch
+from bloch import bloch
 from bloch.rf_seq import hard_pulses, sinc_pulse
 
 from bloch.tests.test_bloch import get_data_with_key


### PR DESCRIPTION
This is a minor suggestion. The way we import the bloch function - `from bloch.bloch import bloch` seemed a little clunky to me. I just made the bloch function directly, so `from bloch import bloch` will now give us the main simulation function, which seems like a cleaner way to import. This also makes behaviour consistent with the instructions in the README.

I also changed the imports in the code to reflect this change. Because I haven't changed any file names or paths, the original import will still work; we just have a cleaner (in my opinion) alternative. I ran the unittests and they passed.