### PR TITLE
Fix import.

### DIFF
--- a/bloch/__init__.py
+++ b/bloch/__init__.py
@@ -1,0 +1,1 @@
+from bloch.bloch import bloch

--- a/bloch/tests/test_bloch.py
+++ b/bloch/tests/test_bloch.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 import scipy.io as sio
 
-from bloch.bloch import bloch
+from bloch import bloch
 
 TEST_DIR = "bloch/tests/test_data"
 

--- a/bloch/tests/test_rf_seq.py
+++ b/bloch/tests/test_rf_seq.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 import scipy as sp
 
-from bloch.bloch import bloch
+from bloch import bloch
 from bloch.rf_seq import hard_pulses, sinc_pulse
 
 from bloch.tests.test_bloch import get_data_with_key


### PR DESCRIPTION
Added the bloch simulation function to \_\_init\_\_.py, so it can now be imported as `from bloch import bloch`, in line with the instructions in the README.